### PR TITLE
Bg fix unique username and email validation 153929602

### DIFF
--- a/server/controllers/v1/userController.js
+++ b/server/controllers/v1/userController.js
@@ -49,7 +49,16 @@ export default class UserController {
         })
         .catch((error) => {
           if (error.name === 'SequelizeUniqueConstraintError') {
-            return res.status(409).json({ message: 'User already exists' });
+            const uniqueErrors = [];
+            error.errors.forEach((uniqueError) => {
+              uniqueErrors.push({
+                path: uniqueError.path,
+                message: `${uniqueError.path.charAt(0).toUpperCase() 
+                  + uniqueError.path.slice(1)} already exist`
+              })
+
+            })
+            return res.status(409).json({ errors: uniqueErrors });
           }
           return res.status(400).send(error);
         });

--- a/server/migrations/20171227191957-remove-user-email-constraint.js
+++ b/server/migrations/20171227191957-remove-user-email-constraint.js
@@ -1,0 +1,23 @@
+'use strict';
+
+module.exports = {
+  up(queryInterface, Sequelize) {
+    queryInterface.removeConstraint('Users' , 'user_email_unique')
+    queryInterface.addConstraint('Users', ['email'], {
+      type: 'unique',
+      name: 'email_unique'
+    });
+    queryInterface.addConstraint('Users', ['username'], {
+      type: 'unique',
+      name: 'username_unique'
+    });
+  },
+  down(queryInterface, Sequelize) {
+    queryInterface.addConstraint('Users', ['username', 'email'], {
+      type: 'unique',
+      name:'user_email_unique'
+    });
+    queryInterface.removeConstraint('Users' , 'email_unique')
+    queryInterface.removeConstraint('Users' , 'username_unique')
+  }
+};

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -11,7 +11,7 @@ export default (sequelize, DataTypes) => {
     username: {
       type: DataTypes.STRING,
       allowNull: false,
-      unique: 'user_email_unique',
+      unique: true,
       validate: {
         notEmpty: {
           args: true,
@@ -58,7 +58,7 @@ export default (sequelize, DataTypes) => {
     email: {
       type: DataTypes.STRING,
       allowNull: false,
-      unique: 'user_email_unique',
+      unique: true,
       validate: {
         notEmpty: {
           args: true,

--- a/server/tests/userControllerTest.js
+++ b/server/tests/userControllerTest.js
@@ -207,7 +207,7 @@ describe('User Endpoint Functionality', () => {
           done(err);
         });
     });
-    it('it should raise validation error for unique username', (done) => {
+    it.only('it should raise validation error for unique username', (done) => {
       const user = userDataTest.validUser1;
       User.create(user).then(() => {
         request.post('/api/v1/users/signup')
@@ -215,7 +215,18 @@ describe('User Endpoint Functionality', () => {
           .set('Accept', 'application/json')
           .end((err, res) => {
             expect(409);
-            expect(res.body.message).to.eql('User already exists');
+            expect(res.body).to.eql({
+              'errors': [
+                {
+                  'path': 'username',
+                  'message': 'Username already exist'
+                },
+                {
+                  'path': 'email',
+                  'message': 'Email already exist'
+                },
+              ]
+            });
             expect(res.status).to.eql(409);
             done(err);
           });


### PR DESCRIPTION
#### What does this PR do?
It add unique validation to the username and email field on the user table
#### Description of Task to be completed?
User should not a be to use and existing username or email on the database
#### How should this be manually tested?
* clone the repo
* run npm install to get project dependencies
* run npm run start-dev to start the server 
* test sign up route on postman, the associated errors should be returned
#### What are the relevant pivotal tracker stories?
153929602
#### Any background context you want to add?
N/A
#### Screenshots
![image](https://user-images.githubusercontent.com/29184825/34402153-3a49b0a6-eba0-11e7-95a3-2e41dc57a0d0.png)
