### PR TITLE
(bug): fix edit profile page

### DIFF
--- a/client/components/userDashBoard/EditProfile.js
+++ b/client/components/userDashBoard/EditProfile.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, Redirect } from 'react-router-dom';
 import { connect } from 'react-redux';
 
 import Footer from '../common/Footer';
@@ -27,7 +27,8 @@ class EditProfile extends Component {
       errors: {},
       isValid: false,
       saving: false,
-      uploadedImage: null
+      uploadedImage: null,
+      redirect: false
 
     }
     this.handleChange = this.handleChange.bind(this);
@@ -35,46 +36,80 @@ class EditProfile extends Component {
     this.handleFileChange = this.handleFileChange.bind(this);
   }
 
-
-  componentWillMount() {
-    this.props.getUserProfile().then(() => {
-      const { profileToEdit } = this.props;
-      this.setState({
-        firstName: profileToEdit.firstName,
-        lastName: profileToEdit.lastName,
-        image: profileToEdit.image
-      })
-    }).catch(() => { })
-  }
-
-
-
+  /**
+   * @returns {void}
+   * 
+   * @memberof EditProfile
+   */
   componentDidMount() {
-
+    this.props.getUserProfile()
   }
 
+  /**
+   * @returns {object} profile to edit
+   * 
+   * @param {any} nextProps 
+   * @memberof EditProfile
+   */
+  componentWillReceiveProps(nextProps) {
+    if(nextProps === this.props) return;
+    const { profileToEdit, updated } = nextProps;
+    if(updated) {
+      setTimeout(() => {
+        this.setState({
+          redirect: true,
+        })
+      }, 2000)
+    }
+    this.setState({
+      firstName: profileToEdit.firstName,
+      lastName: profileToEdit.lastName,
+      image: profileToEdit.image
+    })
+  }
+
+  /**
+   * @returns {object} object containing state
+   * 
+   * @param {any} event 
+   * @memberof EditProfile
+   */
   handleChange(event) {
     this.setState({
       [event.target.name]: event.target.value
     }, () => this.validate())
   }
-
+  /**
+   * @returns {object} edited profile response
+   * 
+   * @param {any} event 
+   * @memberof EditProfile
+   */
   handleSubmit(event) {
     event.preventDefault();
     const userData = this.state;
     this.props.editProfile(userData)
   }
-
+  /**
+   * @returns {files} uploaded image
+   * 
+   * @param {any} event 
+   * @memberof EditProfile
+   */
   handleFileChange(event) {
     const uploadedImage = event.target.files[0];
     this.setState({
       uploadedImage
     }, () => this.validate())
   }
-
+  /**
+   * 
+   * 
+   * @returns {object} validation response status
+   * @memberof EditProfile
+   */
   validate() {
     const { errors, isValid } = InputValidator.updateProfile(this.state);
-    console.log(errors)
     this.setState({ isValid, errors });
     return isValid;
   }
@@ -86,8 +121,10 @@ class EditProfile extends Component {
    * @memberof EditProfile
    */
   render() {
-    const { errors, isValid, saving } = this.state;
+    const { errors, isValid, saving, redirect } = this.state;
     return (
+      redirect ? 
+      <Redirect to='/profile' /> :
       <div>
         <div id="banner">
           <div className="container form-style signin-form">
@@ -121,7 +158,7 @@ class EditProfile extends Component {
                       value={this.state.lastName}
                       errors={errors.lastName}
                     />
-                    <div className="file-field input-field" style={{ top: '1em' }}>
+                    <div className="file-field input-field" style={{ top: '1em', marginTop: 110 }}>
                       <div className="btn"
                         style={{ width: '40%', fontSize: '13px', marginLeft: '1.8em' }}>
                         <span>Photo</span>
@@ -130,7 +167,7 @@ class EditProfile extends Component {
                       </div>
                       <div className="file-path-wrapper">
                         <input className="file-path validate"
-                          type="text" style={{ 'width': '89%' }} />
+                          type="text" style={{ 'width': '89%', marginTop: 9 }} />
                       </div>
                       {errors.image && errors.image.length ?
                         errors.image.map((error, i) => {
@@ -161,6 +198,7 @@ class EditProfile extends Component {
 const mapStateToProps = (state) => {
   return {
     profileToEdit: state.userReducer.profile,
+    updated: state.userReducer.updated
   }
 }
 

--- a/client/components/userDashBoard/UserBorrowedBookListRow.js
+++ b/client/components/userDashBoard/UserBorrowedBookListRow.js
@@ -20,7 +20,6 @@ class UserBorrowedBookListRow extends Component {
    */
   constructor(props) {
     super(props);
-
     this.handleReturn = this.handleReturn.bind(this);
   }
 
@@ -46,7 +45,7 @@ class UserBorrowedBookListRow extends Component {
       <tr>
         <td>{index + 1}</td>
         <td>
-          <Link to={'/book/' + borrowedBook.id}>
+          <Link to={'/book/' + borrowedBook.book.id}>
             {borrowedBook.book.title}
           </Link>
         </td>
@@ -59,9 +58,10 @@ class UserBorrowedBookListRow extends Component {
           borrowedBook.expectedReturnDate}</td>
         <td>
           {borrowedBook.returnStatus == 'accepted' ? 'Returned' :
-            <a 
-            style={{cursor: 'pointer' }}
-            onClick={this.handleReturn}>
+            <a
+              className={`btn-flat 
+              ${borrowedBook.returnStatus === 'pending' ? 'disabled' : null}`}
+              onClick={this.handleReturn}>
               <i className="material-icons">
                 assignment_returned
             </i>

--- a/client/components/userDashBoard/UserProfilePage.js
+++ b/client/components/userDashBoard/UserProfilePage.js
@@ -29,7 +29,7 @@ class UserProfilePage extends Component {
    * 
    * @memberof UserProfilePage
    */
-  componentWillMount() {
+  componentDidMount() {
     this.props.getUserProfile()
   }
   /**

--- a/client/reducers/initialState.js
+++ b/client/reducers/initialState.js
@@ -10,7 +10,8 @@ export default {
     favoriteBooks: [],
     loading: false,
     profile: {},
-    error: ''
+    error: '',
+    updated: false
   },
   books: {
     books: [],

--- a/client/reducers/userReducer.js
+++ b/client/reducers/userReducer.js
@@ -1,6 +1,7 @@
 import initialState from './initialState';
-import { USER_SIGNUP_REQUEST,  SET_CURRENT_USER,
-  USER_BORROW_LIST_SUCCESS, 
+import {
+  USER_SIGNUP_REQUEST, SET_CURRENT_USER,
+  USER_BORROW_LIST_SUCCESS,
   USER_BORROW_LIST_ERROR,
   USER_FAVORITE_LIST,
   USER_FAVORITE_LIST_SUCCESS,
@@ -14,11 +15,16 @@ import { USER_SIGNUP_REQUEST,  SET_CURRENT_USER,
   USER_SIGNIN_SUCCESS,
   USER_SIGNIN_ERROR,
   FETCH_USER_PROFILE_SUCCESS,
-  FETCH_USER_PROFILE_ERROR
+  FETCH_USER_PROFILE_ERROR,
+  EDIT_USER_PROFILE_SUCCESS,
+  EDIT_USER_PROFILE_ERROR,
+  RETURN_SUCCESS,
+  RETURN_ERROR,
+  RETURN
 } from '../actions/actionTypes';
 
 export default (state = initialState.user, action) => {
-  switch(action.type) {
+  switch (action.type) {
     case USER_SIGNUP_REQUEST:
       return {
         ...state,
@@ -36,11 +42,11 @@ export default (state = initialState.user, action) => {
         ...state,
         error: action.error
       }
-    case USER_SIGNIN_REQUEST: 
+    case USER_SIGNIN_REQUEST:
       return {
         ...state
       }
-    case USER_SIGNIN_ERROR: 
+    case USER_SIGNIN_ERROR:
       return {
         ...state,
         error: action.error
@@ -52,24 +58,24 @@ export default (state = initialState.user, action) => {
       }
 
     case USER_BORROW_LIST_ERROR:
-      return { ...state, error: action.error}
+      return { ...state, error: action.error }
 
-    case USER_FAVORITE_LIST: 
+    case USER_FAVORITE_LIST:
       return { ...state, loading: true }
-    
+
     case USER_FAVORITE_LIST_SUCCESS:
       return { ...state, favoriteBooks: action.favoriteBooks, loading: false }
-    
+
     case USER_FAVORITE_LIST_ERROR:
       return { ...state, error: action.error, loading: false }
 
     case REMOVE_FROM_FAVORITES_SUCCESS: {
-      const newFavoriteBooksList = 
-      state.favoriteBooks.filter(favoriteBook => favoriteBook.book.id !== action.bookId)
-      return { ...state, favoriteBooks: newFavoriteBooksList}
+      const newFavoriteBooksList =
+        state.favoriteBooks.filter(favoriteBook => favoriteBook.book.id !== action.bookId)
+      return { ...state, favoriteBooks: newFavoriteBooksList }
     }
-    
-    case REMOVE_FROM_FAVORITES_ERROR: 
+
+    case REMOVE_FROM_FAVORITES_ERROR:
       return { ...state, error: action.error }
 
     case UNSET_CURRENT_USER:
@@ -84,8 +90,32 @@ export default (state = initialState.user, action) => {
 
     case FETCH_USER_PROFILE_ERROR:
       return { ...state, error: action.error };
-    default :
+
+    case EDIT_USER_PROFILE_SUCCESS:
+      return { ...state, profile: action.user, updated: true }
+
+    case EDIT_USER_PROFILE_ERROR:
+      return { ...state, error: action.error, updated: false }
+
+    case RETURN:
+      return { ...state }
+    case RETURN_SUCCESS: {
+      const updatedBorrowedBook =
+      state.borrowedBookHistory.map((borrowedBook) => {
+        return borrowedBook.id == action.borrowedBook.id ? 
+        { ...action.borrowedBook, book: borrowedBook.book } : 
+        borrowedBook
+      });
+      return {
+        ...state,
+        borrowedBookHistory: updatedBorrowedBook
+      }
+    }
+
+    case RETURN_ERROR:
+      return { ...state, error: action.error }
+    default:
       return state
-    
+
   }
 }

--- a/server/controllers/v1/borrowBookController.js
+++ b/server/controllers/v1/borrowBookController.js
@@ -125,7 +125,7 @@ export default class BorrowedBookController {
         });
       } else {
         borrowedBook = await borrowedBook.update({ returnStatus: 'pending' })
-        const reloadedupdatedborrowedBook = borrowedBook.reload();
+        const reloadedupdatedborrowedBook = await borrowedBook.reload();
         return res.status(200).json({
           message: 'Book return request is pending approval by Administrator',
           borrowedBook: reloadedupdatedborrowedBook


### PR DESCRIPTION

#### What does this PR do?

This PR fixes bug on the edit profile page

#### Description of Task to be completed?

* redirect to profile page after edit action is successful
* disable return button after the user attempts to return a book
* await reloaded book return request

#### How should this be manually tested?

* clone the repo
* cd into the project directory
* run `npm install` to install all the dependency
* run `npm run start-dev` to start the back-end server
* run `npm run dev` to start the front-end server
* Navigate to your profile page
* edit your profile 
* on the success you should be redirected back to your profile page
* attempt to return a book you borrow
* the return button should be disabled after that

#### What are the relevant pivotal tracker stories?

[finishes #157995723]

#### Any background context you want to add?

N/A

Screenshots

N/A
